### PR TITLE
Accept JSON pointer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: "perl"
-sudo: false
+os: linux
+dist: xenial
 perl:
   - "5.26"
   - "5.24"
@@ -8,7 +9,10 @@ perl:
   - "5.18"
   - "5.16"
   - "5.14"
-  - "5.12"
+jobs:
+  include:
+  - perl: "5.12"
+    dist: trusty
 
 before_install:
   - mkdir /home/travis/bin || true

--- a/lib/Test/Mojo/Role/Debug/JSON.pm
+++ b/lib/Test/Mojo/Role/Debug/JSON.pm
@@ -9,23 +9,26 @@ with 'Test::Mojo::Role::Debug';
 use Carp qw/croak/;
 
 use Mojo::JSON qw{from_json};
+use Mojo::JSON::Pointer;
 use Test::More ();
 
 # VERSION
 
 sub djson {
-    my ( $self ) = @_;
-    return $self->success ? $self : $self->djsona;
+    my ( $self, $pointer ) = @_;
+    return $self->success ? $self : $self->djsona( $pointer );
 }
 
 sub djsona {
-    my ( $self ) = @_;
+    my ( $self, $pointer ) = @_;
 
     local $@;
     my $json = eval { from_json( $self->tx->res->content->asset->slurp ) };
 
-    Test::More::diag( $@ ) if $@;
-    Test::More::diag( "DEBUG JSON DUMPER:\n", Test::More::explain(  $json ) ) if ref $json;
+    Test::More::diag( $@ ) && return $self if $@;
+    Test::More::diag( "DEBUG JSON DUMPER:\n",
+      Test::More::explain( Mojo::JSON::Pointer->new($json)->get($pointer || '') )
+      ) if ref $json;
 
     return $self;
 }
@@ -79,15 +82,18 @@ You have all the methods provided by L<Test::Mojo>, L<Test::Mojo::Role::Debug>, 
 
 =head2 C<djson>
 
-    $t->djson;         # print the answer as json
+    $t->djson;            # print the answer as json
+    $t->djson('/status'); # print specific node as json
 
 B<Returns> its invocant.
 On failure of previous tests (see L<Mojo::DOM/"success">),
-dumps the content output as json.
+dumps the content output as json. Optionally, takes a JSON pointer to aid subset
+larger responses.
 
 =head2 C<djsona>
 
     $t->djsona;
+    $t->djsona('/status');
 
 Same as L</djson>, except it always dumps, regardless of whether the previous
 test failed or not.

--- a/t/01-tester.t
+++ b/t/01-tester.t
@@ -32,12 +32,13 @@ ok ! $results[-1]->{diag} , '->djson is a NOP when tests are not failing';
 
 ( undef, @results ) = run_tests sub { $t->get_ok('/')->status_is(666)->djson() };
 
-my $json_re = qr|\s*{\s*
-\s*'fruits'\s*=>\s*\[\s*
+my $json_fruit_re = qr|\[\s*
 \s*'apple',\s*
 \s*'banana',\s*
 \s*'cherry'\s*
-\s*\]\s*
+\s*\]|;
+my $json_re = qr|\s*{\s*
+\s*'fruits'\s*=>\s*$json_fruit_re\s*
 \s*}
 |;
 
@@ -49,6 +50,8 @@ like $results[-1]->{diag}, $json_re, "json displayed without failure when using 
 ( undef, @results ) = run_tests sub { $t->get_ok('/')->status_is(600)->djsona() };
 like $results[-1]->{diag}, $json_re, "json displayed with a failure when using ->jsona";
 
+( undef, @results ) = run_tests sub { $t->get_ok('/')->status_is(600)->djson('/fruits') };
+like $results[-1]->{diag}, $json_fruit_re, "json for pointer displayed";
 
 ( undef, @results ) = run_tests sub { $t->get_ok('/')->djson()->status_is(600) };
 unlike $results[-1]->{diag}, qr{banana}, "json not displayed when failure occurs after ->json";


### PR DESCRIPTION
This patch enables `djson` and `djsona` to accept a JSON pointer to subset the JSON written in the diagnostic.

```perl
$t->get_ok('/')
  ->status_is(200)
  ->json_like( { status => 'ok' } )
  ->djson('/status');
# DEBUG JSON DUMPER:
# "good"
```

This is useful with larger responses than this example and is a behaviour more similar to [`Test::Mojo::Role::Debug->d`](https://metacpan.org/pod/Test::Mojo::Role::Debug#d).